### PR TITLE
Prettier Interface - Issue #7

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -6,9 +6,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle "View My Activities" lookup
   myActivitiesBtn.addEventListener("click", async () => {
-    const email = document.getElementById("email").value.trim();
+    const emailInput = document.getElementById("email");
+    const email = emailInput.value.trim();
     if (!email) {
       myActivitiesList.innerHTML = "<p class='error'>Please enter your email above first.</p>";
+      myActivitiesList.classList.remove("hidden");
+      return;
+    }
+    if (!emailInput.checkValidity()) {
+      // Trigger built-in browser validation UI (if available)
+      if (typeof emailInput.reportValidity === "function") {
+        emailInput.reportValidity();
+      }
+      myActivitiesList.innerHTML = "<p class='error'>Please enter a valid email address above first.</p>";
       myActivitiesList.classList.remove("hidden");
       return;
     }
@@ -165,10 +175,22 @@ document.addEventListener("DOMContentLoaded", () => {
   async function handleRegister(event) {
     const button = event.target;
     const activity = button.getAttribute("data-activity");
-    const email = document.getElementById("email").value.trim();
+    const emailInput = document.getElementById("email");
+    const email = emailInput.value.trim();
 
     if (!email) {
       messageDiv.textContent = "Please enter your student email at the top first.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+      return;
+    }
+    if (!emailInput.checkValidity()) {
+      // Trigger built-in browser validation UI (if available)
+      if (typeof emailInput.reportValidity === "function") {
+        emailInput.reportValidity();
+      }
+      messageDiv.textContent = "Please enter a valid student email address at the top first.";
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       setTimeout(() => messageDiv.classList.add("hidden"), 5000);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -71,7 +71,8 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
-        const isFull = spotsLeft === 0;
+        const isFull = spotsLeft <= 0;
+        const displayedSpotsLeft = Math.max(0, spotsLeft);
 
         // Create participants HTML with delete icons
         const participantsHTML =
@@ -93,7 +94,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p class="availability${isFull ? ' full' : ''}"><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <p class="availability${isFull ? ' full' : ''}"><strong>Availability:</strong> ${displayedSpotsLeft} spots left</p>
           <div class="participants-container">
             ${participantsHTML}
           </div>

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,7 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
-  const activitySelect = document.getElementById("activity");
-  const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
   const myActivitiesBtn = document.getElementById("my-activities-btn");
   const myActivitiesList = document.getElementById("my-activities-list");
@@ -72,10 +70,10 @@ document.addEventListener("DOMContentLoaded", () => {
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
 
-        const spotsLeft =
-          details.max_participants - details.participants.length;
+        const spotsLeft = details.max_participants - details.participants.length;
+        const isFull = spotsLeft === 0;
 
-        // Create participants HTML with delete icons instead of bullet points
+        // Create participants HTML with delete icons
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
@@ -95,22 +93,20 @@ document.addEventListener("DOMContentLoaded", () => {
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <p class="availability${isFull ? ' full' : ''}"><strong>Availability:</strong> ${spotsLeft} spots left</p>
           <div class="participants-container">
             ${participantsHTML}
           </div>
+          <button class="register-btn" data-activity="${name}"${isFull ? ' disabled' : ''}>${isFull ? 'Activity Full' : 'Register Student'}</button>
         `;
 
         activitiesList.appendChild(activityCard);
-
-        // Add option to select dropdown
-        const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
-        activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
+      // Add event listeners
+      document.querySelectorAll(".register-btn").forEach((button) => {
+        button.addEventListener("click", handleRegister);
+      });
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
@@ -164,31 +160,30 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  // Handle form submission
-  signupForm.addEventListener("submit", async (event) => {
-    event.preventDefault();
+  // Handle per-card registration
+  async function handleRegister(event) {
+    const button = event.target;
+    const activity = button.getAttribute("data-activity");
+    const email = document.getElementById("email").value.trim();
 
-    const email = document.getElementById("email").value;
-    const activity = document.getElementById("activity").value;
+    if (!email) {
+      messageDiv.textContent = "Please enter your student email at the top first.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+      return;
+    }
 
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/signup?email=${encodeURIComponent(email)}`,
-        {
-          method: "POST",
-        }
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        { method: "POST" }
       );
-
       const result = await response.json();
 
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
-        signupForm.reset();
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -196,18 +191,14 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
+      messageDiv.textContent = "Failed to register. Please try again.";
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
-      console.error("Error signing up:", error);
+      console.error("Error registering:", error);
     }
-  });
+  }
 
   // Initialize app
   fetchActivities();

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -13,30 +13,12 @@
     </header>
 
     <main>
-      <section id="activities-container">
-        <h3>Available Activities</h3>
-        <div id="activities-list">
-          <!-- Activities will be loaded here -->
-          <p>Loading activities...</p>
-        </div>
-      </section>
-
-      <section id="signup-container">
+      <section id="email-bar">
         <h3>Sign Up for an Activity</h3>
-        <form id="signup-form">
-          <div class="form-group">
-            <label for="email">Student Email:</label>
-            <input type="email" id="email" required placeholder="your-email@mergington.edu" />
-          </div>
-          <div class="form-group">
-            <label for="activity">Select Activity:</label>
-            <select id="activity" required>
-              <option value="">-- Select an activity --</option>
-              <!-- Activity options will be loaded here -->
-            </select>
-          </div>
-          <button type="submit">Sign Up</button>
-        </form>
+        <div class="form-group">
+          <label for="email">Student Email:</label>
+          <input type="email" id="email" placeholder="your-email@mergington.edu" />
+        </div>
         <div id="message" class="hidden"></div>
 
         <div id="my-activities-section">
@@ -45,6 +27,14 @@
           <p class="my-activities-hint">Enter your email above and click to see your enrollments.</p>
           <button id="my-activities-btn" type="button">View My Activities</button>
           <div id="my-activities-list" class="hidden"></div>
+        </div>
+      </section>
+
+      <section id="activities-container">
+        <h3>Available Activities</h3>
+        <div id="activities-list">
+          <!-- Activities will be loaded here -->
+          <p>Loading activities...</p>
         </div>
       </section>
     </main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -30,15 +30,9 @@ header h1 {
 
 main {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: center;
   gap: 30px;
-  justify-content: center;
-}
-
-@media (min-width: 768px) {
-  main {
-    grid-template-columns: 2fr 1fr;
-  }
 }
 
 section {
@@ -47,7 +41,22 @@ section {
   border-radius: 5px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   width: 100%;
-  max-width: 500px;
+}
+
+#email-bar {
+  max-width: 600px;
+}
+
+#activities-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 15px;
+}
+
+@media (max-width: 600px) {
+  #activities-list {
+    grid-template-columns: 1fr;
+  }
 }
 
 section h3 {
@@ -58,11 +67,12 @@ section h3 {
 }
 
 .activity-card {
-  margin-bottom: 15px;
   padding: 15px;
   border: 1px solid #ddd;
   border-radius: 5px;
   background-color: #f9f9f9;
+  display: flex;
+  flex-direction: column;
 }
 
 .activity-card h4 {
@@ -197,6 +207,29 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+.register-btn {
+  margin-top: auto;
+  padding-top: 12px;
+  width: 100%;
+  background-color: #0066cc;
+  font-size: 14px;
+  padding: 9px 12px;
+}
+
+.register-btn:hover:not(:disabled) {
+  background-color: #0052a3;
+}
+
+.register-btn:disabled {
+  background-color: #aaa;
+  cursor: not-allowed;
+}
+
+.availability.full {
+  color: #c62828;
+  font-weight: bold;
 }
 
 /* My Activities section */

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -211,7 +211,6 @@ footer {
 
 .register-btn {
   margin-top: auto;
-  padding-top: 12px;
   width: 100%;
   background-color: #0066cc;
   font-size: 14px;


### PR DESCRIPTION
Closes #7

## Changes

- **Layout**: Email input moved to a compact centered card at the top of the page
- **Activity cards**: Now displayed in a responsive CSS grid (3 columns on desktop, 1 on mobile)
- **Registration**: Replaced the side panel dropdown form with a **Register Student** button on each individual card — the button uses whatever email is entered in the top bar
- **Full activities**: Activity Full state is shown with a disabled button and red availability text
- **Removed**: The old side-by-side sign-up form with activity dropdown is gone